### PR TITLE
Fixed incorrect call to init_mijireh()

### DIFF
--- a/includes/class-wc-gateway-mijireh.php
+++ b/includes/class-wc-gateway-mijireh.php
@@ -171,7 +171,7 @@ class WC_Gateway_Mijireh extends WC_Payment_Gateway {
 	 */
 	public function process_payment( $order_id ) {
 
-		$this->init_mijireh();
+		self::init_mijireh();
 
 		$mj_order = new Mijireh_Order();
 		$wc_order = wc_get_order( $order_id );


### PR DESCRIPTION
`WC_Gateway_Mijireh::init_mijireh()` is now declared as `static`, but it was called dynamically in `WC_Gateway_Mijireh::process_payment()`. Probably, it worked anyway due to PHP quirks, but I think it's better to make a clean call.
