### PR TITLE
Tax and line items should be reset before attempting to pass data as lump sum

### DIFF
--- a/includes/class-wc-gateway-mijireh.php
+++ b/includes/class-wc-gateway-mijireh.php
@@ -201,6 +201,10 @@ class WC_Gateway_Mijireh extends WC_Payment_Gateway {
 		}
 
 		if ( true === $send_as_lump ) {
+			// Reset order items and tax  in case we went through the block above
+			$mj_order->clear_items();
+			$mj_order->tax = 0;
+
 			// Don't pass items - Pass 1 item for the order items overall.
 			$item_names = array();
 


### PR DESCRIPTION
Fixes #10.

The debug shown in that ticket shows that data was both sent as individual items and as a lump sum. If the code enters the "send as lump" block, we should make sure to clear out the line items and tax so we don't send data from both (thus leading to a mismatched total..).